### PR TITLE
Fix regex for capturing category and product IDs

### DIFF
--- a/lib/ecwid/index.ts
+++ b/lib/ecwid/index.ts
@@ -725,7 +725,7 @@ export async function getCollections(): Promise<Collection[]> {
 }
 
 export async function getCollection(handle: string): Promise<Collection | undefined> {
-    let categoryId = handle.replace(/^.*?\-c/g, '');
+    let categoryId = handle.replace(/.*(?<=-c)/, '');
 
     const res = await ecwidFetch<EcwidNode>({
         method: 'GET',
@@ -751,7 +751,7 @@ export async function getCollectionProducts({
         baseUrl: '/'
     };
 
-    let categoryId = collection.replace(/^.*?\-c/g, '');
+    let categoryId = collection.replace(/.*(?<=-c)/, '');
 
     if (collection != 'hidden-homepage-carousel' && collection != 'hidden-homepage-featured-items') {
         query.categories = `${categoryId}`;
@@ -805,7 +805,7 @@ export async function getProducts({
 }
 
 export async function getProduct(handle: string): Promise<Product | undefined> {
-    let productId = handle.replace(/^.*?\-p/g, '');
+    let productId = handle.replace(/.*(?<=-p)/, '');
 
     const res = await ecwidFetch<EcwidNode>({
         method: 'GET',


### PR DESCRIPTION
## Fix regex for capturing category and product IDs

The issue was that for product categories with the second or third word starting with the letter "c," the regex used would capture the wrong part of the string, leading to incorrect ID extraction.

For example, for the category "Wireless charger," with the slug "wireless-charger-c12345678" would result in "harger-c12345678" as the ID instead of "12345678." The same issue occurred for products.

This commit fixes the regex to correctly capture the IDs.

## Error on Page

![image](https://github.com/Ecwid/ecwid-nextjs-commerce/assets/36057474/0371006b-9f5e-44b2-83e8-a6aaa41e6c1d)

## Console error

![image](https://github.com/Ecwid/ecwid-nextjs-commerce/assets/36057474/f2c40430-a89c-45e4-b6bb-23c44964acf2)
